### PR TITLE
Update Get-SecInventory.ps1

### DIFF
--- a/Inventory of Authorized and Unauthorized Devices/Get-SecInventory.ps1
+++ b/Inventory of Authorized and Unauthorized Devices/Get-SecInventory.ps1
@@ -1,21 +1,39 @@
-﻿function Get-SecInventory {
+function Get-SecInventory {
 
-Add-CommentHelp -Description Get-SecInventory -Synopsis "Retrieves all computer accounts for a single domain"
+<#
+-Description Get-SecInventory 
+-Synopsis "Retrieves all computer accounts for a single domain"
 
-$strCategory = "computer"
+An array was an easier way of both collecting results and outputting them.
+The strCategory was unnecessary, since it was only called in one location. It was removed to avoid redunancy
+5-17: now creates a baseline list of devices when first run, then compares against baseline with subsequent runs, making a separate XML document listing the differences.
 
-$objDomain = New-Object System.DirectoryServices.DirectoryEntry("LDAP://rootdse")
+#>
 
-$objSearcher = New-Object System.DirectoryServices.DirectorySearcher
+$list=@()
+
+
+$objDomain = New-Object System.DirectoryServices.DirectorySearcher("LDAP://rootdse")
+
 $objSearcher.SearchRoot = $objDomain
-$objSearcher.Filter = ("(objectCategory=$strCategory)")
 
-$colProplist = "name"
-foreach ($i in $colPropList){$objSearcher.PropertiesToLoad.Add($i)}
+$objSearcher.Filter = "objectCategory=computer"
 
-$colResults = $objSearcher.FindAll()
+$objSearcher.FindAll() | Foreach {
+    $list += ([adsi]$_.path).DistinguishedName
+}
 
-foreach ($objResult in $colResults)
-    {$objComputer = $objResult.Properties; $objComputer.name}
-    
+if(-NOT(Test-Path ".\Device-Inventory-Baseline.xml"))
+    {
+    	Write-Output $list | Export-Clixml "Device-Inventory-Baseline.xml"
+		Write-Warning "Baseline list now created. Please re-run this script to check 
+
+for unauthorized devices."
+	Break
+	}
+
+[System.Array]$authorized = Import-Clixml -Path ".\Device-Inventory-Baseline.xml"
+
+[string]$exception = Get-DateISO8601 -Prefix ".\-Unauthorized-Device-Report" -Suffix ".xml"
+Compare-Object $list $authorized | Export-Clixml $exception
 }


### PR DESCRIPTION
now creates a baseline list, should one not exist, then compares to that list with subsequent runs. Creates an exception list for unauthorized devices.
